### PR TITLE
Make changes to Quick Start

### DIFF
--- a/docs/src/QuickStart/Center.md
+++ b/docs/src/QuickStart/Center.md
@@ -1,6 +1,6 @@
 # Quick Start 
 
-In this example, we introduce the `OceanLight` calculation of downwelling irradiance field underneath the flat surfcae. The code example here can be directly pasted onto Julia terminal, run through `.jl` script file, or IJulia notebook. 
+In this example, we introduce the `OceanLight` calculation of downwelling irradiance field underneath the flat surface. The code example here can be directly pasted onto Julia terminal, run through `.jl` script file, or IJulia notebook. 
 
 First, we import `OceanLight` packages and another `random` dependent package, that will be used as a seed to generate random number in the Monte Carlo simulation.
 
@@ -37,7 +37,7 @@ nye = 512                   # Number of grid point of the calculation grid in y 
 num = 31                    # Constant value (number of angle measurement in Kirk,1981)
 ztop = 10                   # Number of grid point in air phase in z direction
 # photon
-nphoton = 10000000           # Number of photons being generated at each grid point 
+nphoton = 10000000          # Number of photons being generated at each grid point 
 kr = 10                     # Dummy variable (in developement, not being used)                    
 nxp = 512                   # Number of grid points in x direction where photon can be emitted
 kbc = 0                     # Binary value 0 and 1 depending on Boundary condition being implemented 
@@ -48,7 +48,7 @@ a = 0.0196                  # Absorbtance coefficient
 pey = 2*pi/20.0             # Lowest wavenumber that can be captured during the derivative of surface elevation in x direction
 nxeta = 512                 # Number of surface elevation grid point in x direction
 nyeta = 512                 # Number of surface elevation grid point in y direction
-pex = 2*pi/20.0              # Lowest wavenumber that can be captured during the derivative of surface elevation in y direction
+pex = 2*pi/20.0             # Lowest wavenumber that can be captured during the derivative of surface elevation in y direction
 ```
 **NOTE:** `num` must be set to a constant value of 31 (number of angle measurement in Kirk, 1981 [^2]). `kbc` accepts only binary values (0 or 1), representing periodic boundary conditions. In contrast to grid spacing `dz` in z-direction, , the grid spacings in the x- and y-directions (`dx` and `dy`) are calculated automatically by `OceanLight.readparams`,  using the formulas $dx \times nxe  = \frac{2\pi}{pex}$, and $dy \times nye = \frac{2\pi}{pey}$. For more detail on all parameters  used, see [`Simulation parameters`](@ref simulation_parameters). 
 

--- a/docs/src/QuickStart/Center.md
+++ b/docs/src/QuickStart/Center.md
@@ -50,7 +50,7 @@ nxeta = 512                 # Number of surface elevation grid point in x direct
 nyeta = 512                 # Number of surface elevation grid point in y direction
 pex = 2*pi/20.0             # Lowest wavenumber that can be captured during the derivative of surface elevation in y direction
 ```
-**NOTE:** `num` must be set to a constant value of 31 (number of angle measurement in Kirk, 1981 [^2]). `kbc` accepts only binary values (0 or 1), representing periodic boundary conditions. In contrast to grid spacing `dz` in z-direction, , the grid spacings in the x- and y-directions (`dx` and `dy`) are calculated automatically by `OceanLight.readparams`,  using the formulas $dx \times nxe  = \frac{2\pi}{pex}$, and $dy \times nye = \frac{2\pi}{pey}$. For more detail on all parameters  used, see [`Simulation parameters`](@ref simulation_parameters). 
+**NOTE:** `num` must be set to a constant value of 31 (number of angle measurement in Kirk, 1981 [^2]). `kbc` accepts only binary values (0 or 1), representing periodic boundary conditions. In contrast to grid spacing `dz` in z-direction, the grid spacings in the x- and y-directions (`dx` and `dy`) are calculated automatically by `OceanLight.readparams`,  using the formulas $dx \times nxe  = \frac{2\pi}{pex}$, and $dy \times nye = \frac{2\pi}{pey}$. For more detail on all parameters  used, see [`Simulation parameters`](@ref simulation_parameters). 
 
 To create a input variable file suitable for this package, user can either create a new file in `.yml` format, copy, and paste the code block above, or using a build-in function `OceanLight.writeparams` to automate the process. 
 
@@ -74,9 +74,7 @@ p = OceanLight.readparams()
 
 Before the simulation, user needs to declare and initialize all parameters and their dimensions. 
 
-### Air-Water Interaction
-
-During the light refraction between two mediums calculation, `OceanLight` requires the surface elevation attribution: $\eta$; surface elevation, $\eta_{x}$; partial derivative of $\eta$ in x direction, and $\eta_{y}$; partial derivative of $\eta$ in y direction. All surface elevation distribution, as specified above, need to have the same dimension with the incoming photons' grid. Hence, 
+During the light refraction between two mediums (air and water) calculation, `OceanLight` requires the surface elevation attribution: $\eta$; surface elevation, $\eta_{x}$; partial derivative of $\eta$ in x direction, and $\eta_{y}$; partial derivative of $\eta$ in y direction. All surface elevation distribution, as specified above, need to have the same dimension with the incoming photons' grid. Hence, 
 
 ```@example Center
 η = zeros(p.nxs,p.nys)
@@ -94,7 +92,17 @@ zpb = zeros(p.nxp,p.nyp);
 fres = zeros(p.nxp,p.nyp);
 ```
 
-### Monte Carlo simulation
+During the air-water interaction process, OceanLight simulates the photons transfer directly downward from the air side, interacts with the water surface, and transfer down into water medium. 
+
+User can generate random surface elevation attribution $\{\eta,\eta_{x},\eta_{y}\}$ with `OceanLight.setwave!`, or provided specific data $\{\eta_{0},\eta_{x0},\eta_{y0}\}$  . OceanLight can map the user's provided data of $\{\eta_{0},\eta_{x0},\eta_{y0}\}$, which might have different dimension onto the suitable dimension of input value $\{η,ηx,ηy\}$ with `OceanLight.convertwave!`.
+
+In this example, we will consider the case of flat surface elevation. Hence, $\{η,ηx,ηy\}$ is equal to the matrix of zeros. 
+
+Once all the input variables are in place, `OceanLight.interface!` calculate the refraction of the light between two medium given surface elevation attribution and return the position, reflectance angle, and transmission ratio. 
+
+```@example Center
+OceanLight.interface!(xpb,ypb,zpb,θ,ϕ,fres,η,ηx,ηy,p)
+```
 
 `OceanLight` tracks the path of each photon travelling inside the water medium and store the irradiance value in the grid `ed`. 
 
@@ -112,21 +120,7 @@ iy = div(p.nyη,2)+1
 ϕps,θps = OceanLight.phasePetzold()
 ```
 
-## Air-Water Interaction
-
-During the air-water interaction process, OceanLight simulates the photons transfer directly downward from the air side, interacts with the water surface, and transfer down into water medium. 
-
-User can generate random surface elevation attribution $\{\eta,\eta_{x},\eta_{y}\}$ with `OceanLight.setwave!`, or provided specific data $\{\eta_{0},\eta_{x0},\eta_{y0}\}$  . OceanLight can map the user's provided data of $\{\eta_{0},\eta_{x0},\eta_{y0}\}$, which might have different dimension onto the suitable dimension of input value $\{η,ηx,ηy\}$ with `OceanLight.convertwave!`.
-
-In this example, we will consider the case of flat surface elevation. Hence, $\{η,ηx,ηy\}$ is equal to the matrix of zeros. 
-
-Once all the input variables are in place, `OceanLight.interface!` calculate the refraction of the light between two medium given surface elevation attribution and return the position, reflectance angle, and transmission ratio. 
-
-```@example Center
-OceanLight.interface!(xpb,ypb,zpb,θ,ϕ,fres,η,ηx,ηy,p)
-```
-
-## Monte Carlo simulation
+## Monte Carlo Simulation
 
 `OceanLight` simulates the photon traveling inside the water medium, given its initial position $\{xpb,ypb,zpb\}$ and the direction it started with$\{θ,ϕ\}$. Once photons are inside the water, `OceanLight` will track its path, governed by its probability distribution and the attenuated coefficient input, and store the irradiance value in the grid `ed`. 
 
@@ -169,22 +163,62 @@ end
 ```
 
 ```@example Center
-using Plots 
+using Plots
 using Plots.Measures
 
-l = @layout [grid(2,1) a{0.5w} ; b{0.5w}]
+# Choose slice indices
+iy_c = 256   # y-index for vertical cross-section
+iz_a = 40    # z-index for panel (a)
+iz_b = 160   # z-index for panel (b)
 
-p1 = heatmap(p.x .-10,p.y .-10,log.(ed[:,:,40]),clim=(-20,0),framestyle = :box,grid = false, c =cgrad(:viridis)
-    ,legend = :none,xlabel="\$x(m)\$",ylabel="\$y(m)\$")
-p2 = heatmap(p.x .-10,p.y .-10,log.(ed[:,:,160]),clim=(-20,0),framestyle = :box,grid = false, c =cgrad(:viridis)
-    ,legend = :none,xlabel="\$x(m)\$",ylabel="\$y(m)\$")
-p3 = heatmap(p.x .-10,reverse(p.z) ,reverse(transpose(log.(ed[:,256,:]))),clim=(-20,0),framestyle = :box,grid = false, c =cgrad(:viridis)
-    ,xlabel="\$x(m)\$",ylabel="\$z(m)\$"
-    ;cbar_title="\$\\ln\\frac{I(x,y,z)}{I_{0}}\$")
-plot(p1, p2,p3, layout = l,
-title = ["($i)" for j in 1:1, i in ["a","b","c"]], titleloc = :left, titlefont = font(8)
-,left_margin = [10mm 0mm],right_margin = [10mm 0mm])
-plot!(size=(900,1200))
+# Define layout: 2 rows, 2 columns, but right column spans both rows
+l = @layout [grid(2,1) c]
+
+# Panel (a) : z = iz_a
+p1 = heatmap(
+    p.x .-10, p.y .-10, log.(ed[:,:,iz_a]),
+    clim=(-20,-7), framestyle=:box, grid=false,
+    c=cgrad(:viridis), legend=:none,
+    xlabel="\$x(m)\$", ylabel="\$y(m)\$",
+    title="(a) z = $(round(p.z[iz_a], digits=1)) m"
+)
+plot!(p1, [minimum(p.x).-10, maximum(p.x).-10], [p.y[iy_c]-10, p.y[iy_c]-10],
+      color=:red, lw=2, ls=:dash)
+
+# Panel (b) : z = iz_b
+p2 = heatmap(
+    p.x .-10, p.y .-10, log.(ed[:,:,iz_b]),
+    clim=(-20,-7), framestyle=:box, grid=false,
+    c=cgrad(:viridis), legend=:none,
+    xlabel="\$x(m)\$", ylabel="\$y(m)\$",
+    title="(b) z = $(round(p.z[iz_b], digits=1)) m"
+)
+plot!(p2, [minimum(p.x).-10, maximum(p.x).-10], [p.y[iy_c]-10, p.y[iy_c]-10],
+      color=:red, lw=2, ls=:dash)
+
+# Panel (c) : vertical cross-section at y = iy_c
+p3 = heatmap(
+    p.x .-10, reverse(p.z), reverse(transpose(log.(ed[:,iy_c,:]))),
+    clim=(-20,-7), framestyle=:box, grid=false,
+    c=cgrad(:viridis), ylim=(-(nz*dz-10),0),
+    xlabel="\$x(m)\$", ylabel="\$z(m)\$",
+    cbar_title="\$\\ln\\frac{I(x,y,z)}{I_{0}}\$",
+    legend=:none,
+    title="(c) y = $(round(p.y[iy_c], digits=1)) m"
+)
+
+# Add horizontal lines for z = iz_a, iz_b
+plot!(p3, [minimum(p.x).-10, maximum(p.x).-10], [p.z[iz_a], p.z[iz_a]],
+      color=:red, lw=1.5, ls=:dash)
+plot!(p3, [minimum(p.x).-10, maximum(p.x).-10], [p.z[iz_b], p.z[iz_b]],
+      color=:red, lw=1.5, ls=:dash)
+
+# Combine
+plot(p1, p2, p3, layout=l,
+     size=(900,700),
+     titleloc=:left, titlefont=font(8),
+     left_margin=10mm, right_margin=10mm)
+
 ```
 
 ## Reference 

--- a/docs/src/QuickStart/Center.md
+++ b/docs/src/QuickStart/Center.md
@@ -180,10 +180,11 @@ p1 = heatmap(
     clim=(-20,-7), framestyle=:box, grid=false,
     c=cgrad(:viridis), legend=:none,
     xlabel="\$x(m)\$", ylabel="\$y(m)\$",
-    title="(a) z = $(round(p.z[iz_a], digits=1)) m"
-)
+    title="(a) z = $(round(p.z[iz_a], digits=1)) m",
+    xlim=[minimum(p.x).-10, maximum(p.x).-10],
+    ylim=[minimum(p.y).-10, maximum(p.y).-10])
 plot!(p1, [minimum(p.x).-10, maximum(p.x).-10], [p.y[iy_c]-10, p.y[iy_c]-10],
-      color=:red, lw=2, ls=:dash)
+      color=:red, lw=2, ls=:dash, alpha=0.6)
 
 # Panel (b) : z = iz_b
 p2 = heatmap(
@@ -191,10 +192,11 @@ p2 = heatmap(
     clim=(-20,-7), framestyle=:box, grid=false,
     c=cgrad(:viridis), legend=:none,
     xlabel="\$x(m)\$", ylabel="\$y(m)\$",
-    title="(b) z = $(round(p.z[iz_b], digits=1)) m"
-)
+    title="(b) z = $(round(p.z[iz_b], digits=1)) m",
+    xlim=[minimum(p.x).-10, maximum(p.x).-10],
+    ylim=[minimum(p.y).-10, maximum(p.y).-10])
 plot!(p2, [minimum(p.x).-10, maximum(p.x).-10], [p.y[iy_c]-10, p.y[iy_c]-10],
-      color=:red, lw=2, ls=:dash)
+      color=:red, lw=2, ls=:dash, alpha=0.6)
 
 # Panel (c) : vertical cross-section at y = iy_c
 p3 = heatmap(
@@ -203,15 +205,14 @@ p3 = heatmap(
     c=cgrad(:viridis), ylim=(-(nz*dz-10),0),
     xlabel="\$x(m)\$", ylabel="\$z(m)\$",
     cbar_title="\$\\ln\\frac{I(x,y,z)}{I_{0}}\$",
-    legend=:none,
-    title="(c) y = $(round(p.y[iy_c], digits=1)) m"
-)
+    title="(c) y = $(round(p.y[iy_c]-10, digits=1)) m",
+    xlim=[minimum(p.x).-10, maximum(p.x).-10])
 
 # Add horizontal lines for z = iz_a, iz_b
 plot!(p3, [minimum(p.x).-10, maximum(p.x).-10], [p.z[iz_a], p.z[iz_a]],
-      color=:red, lw=1.5, ls=:dash)
+      color=:red, lw=1.5, ls=:dash, label="", alpha=0.6)
 plot!(p3, [minimum(p.x).-10, maximum(p.x).-10], [p.z[iz_b], p.z[iz_b]],
-      color=:red, lw=1.5, ls=:dash)
+      color=:red, lw=1.5, ls=:dash, label="", alpha=0.6)
 
 # Combine
 plot(p1, p2, p3, layout=l,


### PR DESCRIPTION
Let me know what you think, but I made the following changes:

- Fixed some typos, like orthographic errors and double commas
- Changed the organization of the tutorial and subtitles to avoid repetition of subtitles
- Changed the overall final plot
    - Fixed layout to avoid blank space at the bottom
    - Added lines in the plots and information about the cross-sections in the panel's titles
    - Changed the colorbar limits to enhance contrast
    - Predefine indexes for cross-sections

Final plot should look like this:

<img width="842" height="713" alt="image" src="https://github.com/user-attachments/assets/f390e9a2-2b43-4f19-b5d6-d41cb6b3a722" />
